### PR TITLE
fix: add nginx to image and use --pull to ensure patched bind/nginx v…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
         
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
               
     # Cache OpenSSL Build to speed up subsequent builds as fips.so should not change often.
     # --load makes the image available locally so we can extract the beats version below.
@@ -150,7 +150,7 @@ jobs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Wait for ECR enhanced scan to become ACTIVE
       env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/usr/lib/ossl-modules
 # Update, upgrade, install packages (including alpine dynamically linked node), and update npm in one layer
 RUN apk update \
     && apk upgrade --no-cache \
-    && apk add --no-cache curl logrotate dnsmasq bind-tools jq bash vim gcompat libc6-compat nodejs npm ca-certificates \ 
+    && apk add --no-cache curl logrotate dnsmasq bind-tools>=9.20.23-r0 nginx>=1.28.3-r2 jq bash vim gcompat libc6-compat nodejs npm ca-certificates \ 
     && npm update -g
 
 # Copy OpenSSL from build stage


### PR DESCRIPTION
…ersions (IGDD-2961, IGDD-2962)

- Explicitly install nginx via apk so it is always present and managed
- Add --pull to docker buildx build so Alpine base is always re-pulled, busting the layer cache for apk upgrade and guaranteeing patched package versions on every daily build (bind 9.20.23-r0, nginx 1.28.3-r2)