### PR TITLE
ci: upgrade GitHub Actions to Node.js 24 and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    labels:
+      - 'dependencies'
+      - 'github-actions'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          ['version-update:semver-patch', 'version-update:semver-minor']

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout the software
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Restore Docker build cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .buildx-cache-snapshot
         key: ${{ runner.os }}-buildx-snapshot-${{ github.sha }}
@@ -38,17 +38,17 @@ jobs:
           ${{ runner.os }}-buildx-snapshot-
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to GitHub Repository
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -56,7 +56,7 @@ jobs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Determine SNAPSHOT version
       id: snap-version
@@ -142,10 +142,10 @@ jobs:
 
     steps:
     - name: Checkout the software
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -153,7 +153,7 @@ jobs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Wait for ECR enhanced scan to become ACTIVE
       env:
@@ -205,7 +205,7 @@ jobs:
         echo "CSV rows: $(wc -l < beats-cve-filtered.csv)"
 
     - name: Upload beats SNAPSHOT CVE report artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: beats-snapshot-cve-report
         path: |
@@ -302,7 +302,7 @@ jobs:
 
     - name: Send email to Elastic
       if: ${{ vars.BEATS_CVE_TEST_EMAIL != '' || github.event_name == 'schedule' }}
-      uses: dawidd6/action-send-mail@v3
+      uses: dawidd6/action-send-mail@v17
       with:
         server_address: email-smtp.us-east-1.amazonaws.com
         server_port: 465

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout the software  
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Resolve component versions
       id: versions
@@ -59,7 +59,7 @@ jobs:
         echo "Resolved: Alpine=${ALPINE_VERSION}@${ALPINE_DIGEST}, OpenSSL=${OPENSSL_VERSION}, Beats=${BEATS_VERSION}"
 
     - name: Restore Docker build cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .buildx-cache
         key: ${{ runner.os }}-buildx-${{ steps.versions.outputs.openssl }}-${{ steps.versions.outputs.beats }}-${{ steps.versions.outputs.alpine_key }}-${{ github.sha }}
@@ -68,17 +68,17 @@ jobs:
           ${{ runner.os }}-buildx-
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to GitHub Repository
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -86,7 +86,7 @@ jobs:
         
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
               
     # Cache OpenSSL Build to speed up subsequent builds as fips.so should not change often.
     # --load makes the image available locally so we can extract the beats version below.
@@ -139,10 +139,10 @@ jobs:
 
     steps:
     - name: Checkout the software
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -150,7 +150,7 @@ jobs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
 
     - name: Wait for ECR enhanced scan to become ACTIVE
       env:
@@ -204,7 +204,7 @@ jobs:
         echo "CSV rows: $(wc -l < beats-cve-filtered.csv)"
 
     - name: Upload beats CVE report artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: beats-cve-report
         path: |
@@ -284,7 +284,7 @@ jobs:
 
     - name: Send email to Elastic
       if: ${{ vars.BEATS_CVE_TEST_EMAIL != '' || github.event_name == 'schedule' }}
-      uses: dawidd6/action-send-mail@v3
+      uses: dawidd6/action-send-mail@v17
       with:
         server_address: email-smtp.us-east-1.amazonaws.com
         server_port: 465


### PR DESCRIPTION
- Updated all workflow actions to their latest stable Node.js 24 compatible versions (node20 deprecated, forced to node24 June 2 2026)
- Added .github/dependabot.yml to keep action versions up-to-date automatically going forward (weekly, major versions only)
