### PR TITLE
IGDD-2982 Restore daily Base Image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,8 @@ name: Docker Build
 
 on:
   schedule:
-    - cron: '0 10 * * 1' # Run weekly on Monday at 10am UTC
+    - cron: '0 10 * * 1'      # Monday 10:00 UTC — build + scan + weekly Elastic email
+    - cron: '0 10 * * 0,2-6'  # Sun, Tue–Sat 10:00 UTC — build + scan only
 
   push:
     branches: 
@@ -212,7 +213,7 @@ jobs:
           beats-cve-filtered.csv
 
     - name: Prepare and send weekly email report
-      if: ${{ vars.BEATS_CVE_TEST_EMAIL != '' || github.event_name == 'schedule' }}
+      if: ${{ github.event.schedule == '0 10 * * 1' || vars.BEATS_CVE_TEST_EMAIL != '' }}
       run: |
         REPORT_DATE=$(date +%Y-%m-%d)
         echo "REPORT_DATE=$REPORT_DATE" >> $GITHUB_ENV
@@ -283,7 +284,7 @@ jobs:
         cd ..
 
     - name: Send email to Elastic
-      if: ${{ vars.BEATS_CVE_TEST_EMAIL != '' || github.event_name == 'schedule' }}
+      if: ${{ github.event.schedule == '0 10 * * 1' || vars.BEATS_CVE_TEST_EMAIL != '' }}
       uses: dawidd6/action-send-mail@v17
       with:
         server_address: email-smtp.us-east-1.amazonaws.com

--- a/openspec/changes/daily-image-build/.openspec.yaml
+++ b/openspec/changes/daily-image-build/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/daily-image-build/design.md
+++ b/openspec/changes/daily-image-build/design.md
@@ -1,0 +1,69 @@
+## Context
+
+`build.yml` currently runs on a single weekly cron (`'0 10 * * 1'`, Monday 10:00
+UTC) plus push/PR/dispatch. The weekly cadence leaves the FIPS base image stale on
+mid-week upstream patches. We want a daily build while keeping the Elastic CVE email
+strictly weekly (Monday) — and today that email is gated on `github.event_name ==
+'schedule'`, so a naive daily cron would email Elastic every day.
+
+The whole change is confined to `build.yml`: the schedule block and the `if:`
+condition on the two report/email steps. No script or Dockerfile changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Build + push + scan the release image daily at 10:00 UTC.
+- Keep the Elastic email and the `cve-reports` commit Monday-only, with identical
+  content, recipients, and week-over-week diff semantics.
+- Preserve the `BEATS_CVE_TEST_EMAIL` manual dry-run path on any day.
+
+**Non-Goals:**
+- Changing `build-snapshot.yml` (stays weekly Monday per commit `8ea1be7`).
+- Changing email content, recipients, the diff logic, or the `cve-reports` branch
+  format.
+- Adding a separate workflow file, ECR lifecycle/retention policy changes, or
+  daylight-saving handling (cron stays UTC).
+
+## Decisions
+
+**Decision 1 — Express the schedule as two non-overlapping crons, not one daily cron.**
+GitHub fires a workflow once per matching cron line. A single `'0 10 * * *'` plus a
+Monday `'0 10 * * 1'` would *both* match on Monday and trigger two runs. So the
+schedule is split into mutually exclusive lines:
+- `'0 10 * * 1'` — Monday (the weekly report run)
+- `'0 10 * * 0,2-6'` — Sunday + Tuesday–Saturday (build/scan only)
+
+Together they cover all seven days with no overlap (cron day-of-week `0` and `6` are
+Sun and Sat; `1` is Mon).
+*Alternative considered:* one `'0 10 * * *'` cron plus a step that computes `date -u
++%u` to detect Monday. Rejected — it adds a moving part and a date dependency, and
+`github.event.schedule` gives the same signal declaratively.
+
+**Decision 2 — Gate the email/commit steps on `github.event.schedule == '0 10 * * 1'`.**
+`github.event.schedule` is populated only for scheduled events and equals the exact
+cron string that fired. This lets the existing `if:` stay a pure expression with no
+date math:
+`if: ${{ github.event.schedule == '0 10 * * 1' || vars.BEATS_CVE_TEST_EMAIL != '' }}`.
+The `BEATS_CVE_TEST_EMAIL` clause is unchanged, so dispatch/push test runs behave
+exactly as before. The cron string must match the schedule entry character-for-character.
+
+**Decision 3 — Let the scan + artifact run daily; gate only email + commit.**
+The `beats-cve-report` job (poll → retrieve → filter → upload artifact) is cheap and
+runs every day; only the two reporting steps are Monday-gated. This keeps the diff
+baseline clean: because the `cve-reports` commit happens only on Monday, each Monday
+still diffs against the previous Monday's dated report — week-over-week semantics are
+unchanged.
+
+## Risks / Trade-offs
+
+- **Cron-string drift** → If someone edits the Monday cron entry but not the `if:`
+  expression (or vice versa), the email silently stops or starts firing daily. The
+  `daily-image-build` spec records the exact strings; verification (below) exercises
+  both a Monday and a non-Monday run.
+- **DST** → 10:00 UTC is 6am ET only during EDT; in winter it is 5am ET. Accepted —
+  GitHub cron is UTC-only and the exact local minute is not important for a build.
+- **~7× more scheduled runs** → More CI minutes and faster-accumulating ECR
+  `:<run-number>` tags. Buildx local cache keeps no-op daily builds fast; ECR
+  retention is out of scope but worth a follow-up if tag count becomes an issue.
+- **GitHub may skip scheduled runs under load / on inactive repos** → Inherent to
+  Actions cron; unchanged by this design and acceptable for a daily rebuild.

--- a/openspec/changes/daily-image-build/proposal.md
+++ b/openspec/changes/daily-image-build/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+The release image build in `build.yml` runs only once a week (Monday 10:00 UTC).
+For a FIPS base image whose whole value is shipping current crypto and patched
+OS/Beats packages, a weekly rebuild means up to six days of staleness — Alpine,
+OpenSSL 3.5.x, and Beats fixes published mid-week aren't picked up until the next
+Monday. The weekly-only cadence was a mistake; the image should rebuild **daily**
+so it absorbs upstream patches within a day.
+
+The constraint: the weekly CVE email to Elastic must **not** change. Today that
+email is driven by the `schedule` event, so naively switching the cron to daily
+would fire the report to Elastic every day. We need daily builds while keeping the
+Elastic email (and its `cve-reports` commit) strictly weekly on Monday.
+
+## What Changes
+
+- `build.yml` schedule changes from a single weekly Monday cron to a daily cron,
+  keeping the existing 10:00 UTC time (= 6am US Eastern during EDT). To avoid a
+  Monday double-fire, this is expressed as two non-overlapping crons:
+  - `'0 10 * * 1'` — Monday: build + scan + weekly Elastic email + `cve-reports` commit
+  - `'0 10 * * 0,2-6'` — Sun, Tue–Sat: build + scan only
+- The two already-gated steps (`Prepare and send weekly email report` and
+  `Send email to Elastic`) change their gate from `github.event_name == 'schedule'`
+  to `github.event.schedule == '0 10 * * 1'`, so the email + branch commit fire only
+  on the Monday scheduled run. The `BEATS_CVE_TEST_EMAIL` test-mode clause is retained
+  unchanged, so manual dry-runs still work on any day.
+- The `build` and `beats-cve-report` jobs otherwise run every day: image build/push,
+  ECR scan, beats filtering, and the GitHub Actions artifact upload all happen daily.
+  The weekly email's week-over-week diff is unaffected because the `cve-reports`
+  branch is still only committed on Monday, so each Monday still diffs against the
+  previous Monday's dated report.
+- `build-snapshot.yml` is intentionally left unchanged (stays weekly Monday, per the
+  deliberate decision in commit `8ea1be7`). `build-snapshot-placeholder.yml` is
+  untouched.
+
+No new external dependencies, secrets, or repository variables. No change to email
+content, recipients, subject, attachments, the diff logic, or the `cve-reports`
+branch format.
+
+## Capabilities
+
+### New Capabilities
+- `daily-image-build`: The release image is built and pushed on a daily schedule
+  (10:00 UTC) in addition to push/PR/manual-dispatch triggers, using a two-cron
+  structure that singles out the Monday run for weekly reporting. Capturing this as
+  a requirement prevents a future revert of the cron back to weekly-only.
+
+### Modified Capabilities
+- `weekly-email-report`: The "Trigger Gating" requirement narrows from *any*
+  `schedule` event to the **Monday** scheduled run (`'0 10 * * 1'`). The email and
+  `cve-reports` commit steps SHALL run on the Monday schedule or in test mode, and
+  SHALL be skipped on non-Monday scheduled runs (which still build and scan).
+
+## Impact
+
+- **Affected file**: `.github/workflows/build.yml` (schedule block + the `if:` on the
+  two email/commit steps). No script changes.
+- **Considered but unaffected**:
+  - `daily-cve-scan` — the `beats-cve-report` job still runs after every successful
+    build; daily builds simply make "after every build" a daily occurrence. No
+    requirement change.
+  - `cve-reports-branch` — filename format, `[skip ci]` hygiene, and retention are
+    unchanged; the branch is just committed only on Mondays now (gating owned by
+    `weekly-email-report`).
+  - `build-snapshot.yml` and `build-snapshot-placeholder.yml` — out of scope.
+- **Operational effect**: ~7× more scheduled runs (CI minutes, ECR pushes, run-number
+  tags). Buildx local cache keeps incremental daily builds fast when no upstream
+  versions changed. ECR `:<run-number>` tags accumulate faster — note for any image
+  retention/lifecycle policy, but not changed here.
+- **Jira**: IGDD-2982.

--- a/openspec/changes/daily-image-build/specs/daily-image-build/spec.md
+++ b/openspec/changes/daily-image-build/specs/daily-image-build/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Daily Build Schedule
+The `build.yml` workflow SHALL build and push the release image on a daily
+schedule at 10:00 UTC, in addition to its existing push, pull_request, and
+workflow_dispatch triggers. This daily schedule replaces the previous
+weekly Monday-only schedule (`'0 10 * * 1'`).
+
+#### Scenario: Daily scheduled build
+- **WHEN** the 10:00 UTC schedule fires on any day of the week
+- **THEN** the `build` job builds the image and pushes it to ECR (`:<run-number>` and `:latest`) and ghcr.io (`:latest`)
+
+#### Scenario: Mid-week upstream patch
+- **WHEN** a new Alpine digest, OpenSSL 3.5.x release, or Beats release is published on a non-Monday
+- **THEN** the next daily scheduled build picks it up within a day instead of waiting for the following Monday
+
+### Requirement: Non-Overlapping Cron Entries
+The daily schedule SHALL be expressed as two non-overlapping cron entries so
+that exactly one scheduled run occurs per day and the Monday run is
+distinguishable for weekly reporting: `'0 10 * * 1'` (Monday) and
+`'0 10 * * 0,2-6'` (Sunday, Tuesday–Saturday). A single `'0 10 * * *'` cron
+combined with a Monday cron SHALL NOT be used, because both would match on
+Monday and trigger two runs.
+
+#### Scenario: No Monday double-fire
+- **WHEN** the schedule fires on Monday at 10:00 UTC
+- **THEN** only the `'0 10 * * 1'` cron matches and the workflow runs exactly once
+
+#### Scenario: Monday run is identifiable
+- **WHEN** the workflow is triggered by the Monday schedule
+- **THEN** `github.event.schedule` equals `'0 10 * * 1'`, allowing downstream steps to gate weekly-only behavior
+
+#### Scenario: Non-Monday run is identifiable
+- **WHEN** the workflow is triggered by the Sunday/Tuesday–Saturday schedule
+- **THEN** `github.event.schedule` equals `'0 10 * * 0,2-6'`

--- a/openspec/changes/daily-image-build/specs/weekly-email-report/spec.md
+++ b/openspec/changes/daily-image-build/specs/weekly-email-report/spec.md
@@ -3,9 +3,11 @@
 ### Requirement: Trigger Gating
 The email and cve-reports branch commit steps SHALL only execute on the weekly
 Monday scheduled run (the cron `'0 10 * * 1'`), or when the repository variable
-BEATS_CVE_TEST_EMAIL is set (test mode). Non-Monday scheduled runs (the cron
-`'0 10 * * 0,2-6'`), workflow_dispatch, and push triggers SHALL skip these steps
-unless BEATS_CVE_TEST_EMAIL is set. The gate SHALL be expressed as
+BEATS_CVE_TEST_EMAIL is set on a trigger where the beats-cve-report job runs
+(test mode). Non-Monday scheduled runs (the cron `'0 10 * * 0,2-6'`),
+workflow_dispatch, and push triggers SHALL skip these steps unless
+BEATS_CVE_TEST_EMAIL is set. Pull requests remain excluded because the
+beats-cve-report job is skipped for pull_request events. The gate SHALL be expressed as
 `github.event.schedule == '0 10 * * 1'` rather than
 `github.event_name == 'schedule'`, because the workflow now runs on a daily
 schedule and only the Monday run is the weekly report.
@@ -23,5 +25,5 @@ schedule and only the Monday run is the weekly report.
 - **THEN** the email and branch-commit steps are skipped without error
 
 #### Scenario: Test mode
-- **WHEN** BEATS_CVE_TEST_EMAIL is set on any trigger
+- **WHEN** BEATS_CVE_TEST_EMAIL is set on a non-pull_request trigger where the beats-cve-report job runs
 - **THEN** the email step executes and sends to the address in BEATS_CVE_TEST_EMAIL

--- a/openspec/changes/daily-image-build/specs/weekly-email-report/spec.md
+++ b/openspec/changes/daily-image-build/specs/weekly-email-report/spec.md
@@ -1,0 +1,27 @@
+## MODIFIED Requirements
+
+### Requirement: Trigger Gating
+The email and cve-reports branch commit steps SHALL only execute on the weekly
+Monday scheduled run (the cron `'0 10 * * 1'`), or when the repository variable
+BEATS_CVE_TEST_EMAIL is set (test mode). Non-Monday scheduled runs (the cron
+`'0 10 * * 0,2-6'`), workflow_dispatch, and push triggers SHALL skip these steps
+unless BEATS_CVE_TEST_EMAIL is set. The gate SHALL be expressed as
+`github.event.schedule == '0 10 * * 1'` rather than
+`github.event_name == 'schedule'`, because the workflow now runs on a daily
+schedule and only the Monday run is the weekly report.
+
+#### Scenario: Monday schedule trigger
+- **WHEN** the workflow is triggered by the Monday schedule (`github.event.schedule == '0 10 * * 1'`)
+- **THEN** the email step executes and sends to production recipients, and the report is committed to the cve-reports branch
+
+#### Scenario: Non-Monday schedule trigger
+- **WHEN** the workflow is triggered by a non-Monday scheduled run (`github.event.schedule == '0 10 * * 0,2-6'`) and BEATS_CVE_TEST_EMAIL is not set
+- **THEN** the build and beats-cve-report scan/artifact steps run, but the email and cve-reports branch-commit steps are skipped without error
+
+#### Scenario: workflow_dispatch without test email
+- **WHEN** the workflow is triggered by workflow_dispatch and BEATS_CVE_TEST_EMAIL is not set
+- **THEN** the email and branch-commit steps are skipped without error
+
+#### Scenario: Test mode
+- **WHEN** BEATS_CVE_TEST_EMAIL is set on any trigger
+- **THEN** the email step executes and sends to the address in BEATS_CVE_TEST_EMAIL

--- a/openspec/changes/daily-image-build/tasks.md
+++ b/openspec/changes/daily-image-build/tasks.md
@@ -1,0 +1,53 @@
+# Tasks: daily-image-build
+
+Implementation is confined to `.github/workflows/build.yml`. No script, Dockerfile,
+secret, or repository-variable changes are required.
+
+---
+
+## 1. Schedule
+
+- [ ] 1.1 In `build.yml`, replace the single `schedule` cron `'0 10 * * 1'` with two
+  non-overlapping entries, keeping the 10:00 UTC time:
+  ```yaml
+  schedule:
+    - cron: '0 10 * * 1'      # Monday 10:00 UTC — build + scan + weekly Elastic email
+    - cron: '0 10 * * 0,2-6'  # Sun, Tue–Sat 10:00 UTC — build + scan only
+  ```
+- [ ] 1.2 Confirm the two crons do not overlap (no day matches both) so Monday fires
+  exactly once.
+
+## 2. Monday-Only Email/Commit Gate
+
+- [ ] 2.1 In the `Prepare and send weekly email report` step, change the `if:` from
+  `${{ vars.BEATS_CVE_TEST_EMAIL != '' || github.event_name == 'schedule' }}` to
+  `${{ github.event.schedule == '0 10 * * 1' || vars.BEATS_CVE_TEST_EMAIL != '' }}`.
+- [ ] 2.2 Apply the identical `if:` change to the `Send email to Elastic` step.
+- [ ] 2.3 Confirm the cron string in both `if:` expressions matches the Monday
+  `schedule` entry from task 1.1 character-for-character.
+
+## 3. Sanity Checks
+
+- [ ] 3.1 Lint/parse the workflow YAML (e.g. `actionlint .github/workflows/build.yml`
+  or a YAML parser) to confirm it is well-formed.
+- [ ] 3.2 Re-read the `build` and `beats-cve-report` jobs to confirm nothing else
+  gates on `github.event_name == 'schedule'` (so daily build/scan/artifact still run
+  every day and only email + commit are Monday-gated).
+
+## 4. Verification
+
+- [ ] 4.1 Trigger a `workflow_dispatch` run with `BEATS_CVE_TEST_EMAIL` **set** to your
+  own address. Verify: image builds/pushes, the `beats-cve-report` artifact uploads,
+  the test email arrives, and a `-run-N` report is committed to the `cve-reports`
+  branch (test-mode path unchanged by this change).
+- [ ] 4.2 Trigger a `workflow_dispatch` run with `BEATS_CVE_TEST_EMAIL` **unset**.
+  Verify the build + artifact still happen and the email + `cve-reports` commit are
+  skipped without error.
+- [ ] 4.3 Confirm the schedule on GitHub: the next scheduled runs appear daily (not
+  only Monday) in the Actions UI / `gh workflow view`.
+- [ ] 4.4 After (or by inspecting) a **non-Monday** scheduled run, confirm it builds +
+  scans + uploads the artifact but does **not** email or commit to `cve-reports`.
+- [ ] 4.5 After (or by inspecting) the **Monday** scheduled run, confirm the Elastic
+  email goes out with the week-over-week diff against the previous Monday's dated
+  report, and the dated report is committed to `cve-reports` with `[skip ci]`.
+- [ ] 4.6 Clear `BEATS_CVE_TEST_EMAIL` once testing is complete.

--- a/openspec/changes/daily-image-build/tasks.md
+++ b/openspec/changes/daily-image-build/tasks.md
@@ -36,11 +36,11 @@ secret, or repository-variable changes are required.
 
 ## 4. Verification
 
-- [ ] 4.1 Trigger a `workflow_dispatch` run with `BEATS_CVE_TEST_EMAIL` **set** to your
+- [x] 4.1 Trigger a `workflow_dispatch` run with `BEATS_CVE_TEST_EMAIL` **set** to your
   own address. Verify: image builds/pushes, the `beats-cve-report` artifact uploads,
   the test email arrives, and a `-run-N` report is committed to the `cve-reports`
   branch (test-mode path unchanged by this change).
-- [ ] 4.2 Trigger a `workflow_dispatch` run with `BEATS_CVE_TEST_EMAIL` **unset**.
+- [x] 4.2 Trigger a `workflow_dispatch` run with `BEATS_CVE_TEST_EMAIL` **unset**.
   Verify the build + artifact still happen and the email + `cve-reports` commit are
   skipped without error.
 - [ ] 4.3 Confirm the schedule on GitHub: the next scheduled runs appear daily (not

--- a/openspec/changes/daily-image-build/tasks.md
+++ b/openspec/changes/daily-image-build/tasks.md
@@ -7,30 +7,30 @@ secret, or repository-variable changes are required.
 
 ## 1. Schedule
 
-- [ ] 1.1 In `build.yml`, replace the single `schedule` cron `'0 10 * * 1'` with two
+- [x] 1.1 In `build.yml`, replace the single `schedule` cron `'0 10 * * 1'` with two
   non-overlapping entries, keeping the 10:00 UTC time:
   ```yaml
   schedule:
     - cron: '0 10 * * 1'      # Monday 10:00 UTC — build + scan + weekly Elastic email
     - cron: '0 10 * * 0,2-6'  # Sun, Tue–Sat 10:00 UTC — build + scan only
   ```
-- [ ] 1.2 Confirm the two crons do not overlap (no day matches both) so Monday fires
+- [x] 1.2 Confirm the two crons do not overlap (no day matches both) so Monday fires
   exactly once.
 
 ## 2. Monday-Only Email/Commit Gate
 
-- [ ] 2.1 In the `Prepare and send weekly email report` step, change the `if:` from
+- [x] 2.1 In the `Prepare and send weekly email report` step, change the `if:` from
   `${{ vars.BEATS_CVE_TEST_EMAIL != '' || github.event_name == 'schedule' }}` to
   `${{ github.event.schedule == '0 10 * * 1' || vars.BEATS_CVE_TEST_EMAIL != '' }}`.
-- [ ] 2.2 Apply the identical `if:` change to the `Send email to Elastic` step.
-- [ ] 2.3 Confirm the cron string in both `if:` expressions matches the Monday
+- [x] 2.2 Apply the identical `if:` change to the `Send email to Elastic` step.
+- [x] 2.3 Confirm the cron string in both `if:` expressions matches the Monday
   `schedule` entry from task 1.1 character-for-character.
 
 ## 3. Sanity Checks
 
-- [ ] 3.1 Lint/parse the workflow YAML (e.g. `actionlint .github/workflows/build.yml`
+- [x] 3.1 Lint/parse the workflow YAML (e.g. `actionlint .github/workflows/build.yml`
   or a YAML parser) to confirm it is well-formed.
-- [ ] 3.2 Re-read the `build` and `beats-cve-report` jobs to confirm nothing else
+- [x] 3.2 Re-read the `build` and `beats-cve-report` jobs to confirm nothing else
   gates on `github.event_name == 'schedule'` (so daily build/scan/artifact still run
   every day and only email + commit are Monday-gated).
 


### PR DESCRIPTION
Doesn't change any of the added scan/email functionality added to communicate CVE's out to Beats.  Restores daily builds.