### PR TITLE
fix: bust Docker layer cache on any Alpine package update (IGDD-3071)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,15 +57,24 @@ jobs:
         fi
         echo "beats=${BEATS_VERSION}" >> $GITHUB_OUTPUT
 
-        echo "Resolved: Alpine=${ALPINE_VERSION}@${ALPINE_DIGEST}, OpenSSL=${OPENSSL_VERSION}, Beats=${BEATS_VERSION}"
+        # Node: resolve current version packaged in Alpine 3.23
+        NODE_VERSION=$(curl -s "https://pkgs.alpinelinux.org/package/v3.23/main/x86_64/nodejs" \
+          | grep -oP '(?<=<strong>)\d+\.\d+\.\d+(?=-r\d+</strong>)' | head -1)
+        if [ -z "$NODE_VERSION" ]; then
+          echo "WARNING: Failed to fetch Node version from Alpine, using fallback 24.17.0"
+          NODE_VERSION=24.17.0
+        fi
+        echo "node=${NODE_VERSION}" >> $GITHUB_OUTPUT
+
+        echo "Resolved: Alpine=${ALPINE_VERSION}@${ALPINE_DIGEST}, OpenSSL=${OPENSSL_VERSION}, Beats=${BEATS_VERSION}, Node=${NODE_VERSION}"
 
     - name: Restore Docker build cache
       uses: actions/cache@v5
       with:
         path: .buildx-cache
-        key: ${{ runner.os }}-buildx-${{ steps.versions.outputs.openssl }}-${{ steps.versions.outputs.beats }}-${{ steps.versions.outputs.alpine_key }}-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-${{ steps.versions.outputs.openssl }}-${{ steps.versions.outputs.beats }}-${{ steps.versions.outputs.node }}-${{ steps.versions.outputs.alpine_key }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-buildx-${{ steps.versions.outputs.openssl }}-${{ steps.versions.outputs.beats }}-${{ steps.versions.outputs.alpine_key }}-
+          ${{ runner.os }}-buildx-${{ steps.versions.outputs.openssl }}-${{ steps.versions.outputs.beats }}-${{ steps.versions.outputs.node }}-${{ steps.versions.outputs.alpine_key }}-
           ${{ runner.os }}-buildx-
 
     - name: Set up Docker Buildx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
             --build-arg OPENSSL_VERSION=${{ steps.versions.outputs.openssl }} \
             --build-arg BEATS_VERSION_OVERRIDE=${{ steps.versions.outputs.beats }} \
             --build-arg APK_INDEX_HASH=${{ steps.versions.outputs.apk_index }} \
-            --cache-from=type=local,src=.buildx-cache --cache-to=type=local,dest=.buildx-cache \
+            --cache-from=type=local,src=.buildx-cache --cache-to=type=local,dest=.buildx-cache,mode=max \
             -t ghcr.io/izgateway/alpine-node-openssl-fips:latest \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:${{github.run_number}} \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,24 +57,23 @@ jobs:
         fi
         echo "beats=${BEATS_VERSION}" >> $GITHUB_OUTPUT
 
-        # Node: resolve current version packaged in Alpine 3.23
-        NODE_VERSION=$(curl -s "https://pkgs.alpinelinux.org/package/v3.23/main/x86_64/nodejs" \
-          | grep -oP '(?<=<strong>)\d+\.\d+\.\d+(?=-r\d+</strong>)' | head -1)
-        if [ -z "$NODE_VERSION" ]; then
-          echo "WARNING: Failed to fetch Node version from Alpine, using fallback 24.17.0"
-          NODE_VERSION=24.17.0
+        # Alpine package index: hash detects any package update (nodejs, nginx, gcc, etc.)
+        APK_INDEX_HASH=$(curl -sL https://dl-cdn.alpinelinux.org/alpine/v3.23/main/x86_64/APKINDEX.tar.gz | sha256sum | cut -d' ' -f1)
+        if [ -z "$APK_INDEX_HASH" ]; then
+          echo "WARNING: Failed to fetch Alpine package index hash"
+          APK_INDEX_HASH="unknown"
         fi
-        echo "node=${NODE_VERSION}" >> $GITHUB_OUTPUT
+        echo "apk_index=${APK_INDEX_HASH}" >> $GITHUB_OUTPUT
 
-        echo "Resolved: Alpine=${ALPINE_VERSION}@${ALPINE_DIGEST}, OpenSSL=${OPENSSL_VERSION}, Beats=${BEATS_VERSION}, Node=${NODE_VERSION}"
+        echo "Resolved: Alpine=${ALPINE_VERSION}@${ALPINE_DIGEST}, OpenSSL=${OPENSSL_VERSION}, Beats=${BEATS_VERSION}, APK_INDEX=${APK_INDEX_HASH}"
 
     - name: Restore Docker build cache
       uses: actions/cache@v5
       with:
         path: .buildx-cache
-        key: ${{ runner.os }}-buildx-${{ steps.versions.outputs.openssl }}-${{ steps.versions.outputs.beats }}-${{ steps.versions.outputs.node }}-${{ steps.versions.outputs.alpine_key }}-${{ github.sha }}
+        key: ${{ runner.os }}-buildx-${{ steps.versions.outputs.openssl }}-${{ steps.versions.outputs.beats }}-${{ steps.versions.outputs.apk_index }}-${{ steps.versions.outputs.alpine_key }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-buildx-${{ steps.versions.outputs.openssl }}-${{ steps.versions.outputs.beats }}-${{ steps.versions.outputs.node }}-${{ steps.versions.outputs.alpine_key }}-
+          ${{ runner.os }}-buildx-${{ steps.versions.outputs.openssl }}-${{ steps.versions.outputs.beats }}-${{ steps.versions.outputs.apk_index }}-${{ steps.versions.outputs.alpine_key }}-
           ${{ runner.os }}-buildx-
 
     - name: Set up Docker Buildx
@@ -116,6 +115,7 @@ jobs:
             --build-arg alpineVersion=${{ steps.versions.outputs.alpine_ref }} \
             --build-arg OPENSSL_VERSION=${{ steps.versions.outputs.openssl }} \
             --build-arg BEATS_VERSION_OVERRIDE=${{ steps.versions.outputs.beats }} \
+            --build-arg APK_INDEX_HASH=${{ steps.versions.outputs.apk_index }} \
             --cache-from=type=local,src=.buildx-cache --cache-to=type=local,dest=.buildx-cache \
             -t ghcr.io/izgateway/alpine-node-openssl-fips:latest \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:${{github.run_number}} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM alpine:$alpineVersion AS openssl-build
 
 # Passed in from the workflow; falls back to API fetch if empty.
 ARG OPENSSL_VERSION=""
+ARG APK_INDEX_HASH
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 
@@ -55,6 +56,8 @@ RUN awk '/^# For FIPS/ { print; system("cat /tmp/openssl_fips_insert.txt"); skip
     
 # Stage 2: Main image
 FROM alpine:$alpineVersion
+
+ARG APK_INDEX_HASH
 
 ENV OPENSSL_FIPS=1
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/usr/lib/ossl-modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ ARG APK_INDEX_HASH
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 
-RUN apk update \
+RUN echo "APK index hash: ${APK_INDEX_HASH}" \
+    && apk update \
     && apk upgrade --no-cache \
     && apk add --no-cache bash gcompat libc6-compat curl jq
 
@@ -63,7 +64,8 @@ ENV OPENSSL_FIPS=1
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/usr/lib/ossl-modules
 
 # Update, upgrade, install packages (including alpine dynamically linked node), and update npm in one layer
-RUN apk update \
+RUN echo "APK index hash: ${APK_INDEX_HASH}" \
+    && apk update \
     && apk upgrade --no-cache \
     && apk add --no-cache curl logrotate dnsmasq bind-tools>=9.20.23-r0 nginx>=1.28.3-r4 jq bash vim gcompat libc6-compat nodejs npm ca-certificates \ 
     && npm update -g

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ ARG APK_INDEX_HASH
 
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
 
+# The echo references APK_INDEX_HASH so Docker invalidates this layer's cache
+# when the Alpine package index changes. Without a reference in the RUN command,
+# Docker ignores ARG changes for cache purposes (invalidation triggers on first
+# usage, not declaration). Do not remove the echo.
 RUN echo "APK index hash: ${APK_INDEX_HASH}" \
     && apk update \
     && apk upgrade --no-cache \
@@ -63,6 +67,10 @@ ARG APK_INDEX_HASH
 ENV OPENSSL_FIPS=1
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:/usr/lib/ossl-modules
 
+# The echo references APK_INDEX_HASH so Docker invalidates this layer's cache
+# when the Alpine package index changes. Without a reference in the RUN command,
+# Docker ignores ARG changes for cache purposes (invalidation triggers on first
+# usage, not declaration). Do not remove the echo.
 # Update, upgrade, install packages (including alpine dynamically linked node), and update npm in one layer
 RUN echo "APK index hash: ${APK_INDEX_HASH}" \
     && apk update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Dockerfile
 ARG alpineVersion=3.23
-ARG nodeVersion=24
 
 # Stage 1: Build OpenSSL FIPS
 FROM alpine:$alpineVersion AS openssl-build


### PR DESCRIPTION
## Summary

- Replaces per-package Node.js version scraping with a `sha256` hash of the Alpine 3.23 `APKINDEX.tar.gz`, covering every `apk`-installed package in both build stages
- Includes the hash as `APK_INDEX_HASH` build-arg so Docker's layer cache is invalidated even when a restore-key fallback loads a stale entry
- Applies to both the OpenSSL FIPS compile stage (compiler, linker, build libs) and the runtime stage (nodejs, nginx, bind-tools, etc.)
- Removes the unused `ARG nodeVersion=24` from the Dockerfile

## Test plan

- [x] Confirm CI build passes on this branch
- [ ] Confirm the `Resolve component versions` step logs an `APK_INDEX=<hash>` line
- [ ] Confirm the cache key in `Restore Docker build cache` includes the hash segment
- [ ] Confirm `ARG APK_INDEX_HASH` appears in both Dockerfile stages before their `apk add` layers

Fixes [IGDD-3071](https://izgateway.atlassian.net/browse/IGDD-3071)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[IGDD-3071]: https://izgateway.atlassian.net/browse/IGDD-3071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ